### PR TITLE
Implement Gemini Live stream service

### DIFF
--- a/app/api/interview/generate-real-audio/route.ts
+++ b/app/api/interview/generate-real-audio/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server"
+import { GeminiStreamService } from "@/lib/gemini-stream-service"
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { text, voice = "Kore" } = body
+
+    if (!text) {
+      return NextResponse.json({ success: false, error: "Text is required" }, { status: 400 })
+    }
+
+    const apiKey = process.env.GOOGLE_AI_API_KEY
+    if (!apiKey) {
+      return NextResponse.json({ success: false, error: "API key not configured" }, { status: 500 })
+    }
+
+    const audioChunks: string[] = []
+    const service = new GeminiStreamService(
+      apiKey,
+      {
+        job: { title: "Test", company: "Test" },
+        questions: { technical: [], behavioral: [] },
+        voice,
+      },
+      {
+        onAudio: (data) => audioChunks.push(data),
+      },
+    )
+
+    await service.startSession()
+    service.sendText(text)
+
+    // Wait briefly to allow audio to stream
+    await new Promise((r) => setTimeout(r, 2000))
+
+    service.close()
+
+    return NextResponse.json({
+      success: true,
+      message: "Audio generated via Gemini Live API",
+      audioData: audioChunks.join(""),
+      details: { chunksReceived: audioChunks.length },
+    })
+  } catch (error: any) {
+    console.error("generate-real-audio error:", error)
+    return NextResponse.json(
+      { success: false, error: error.message || "Unknown error" },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/interview/test-gemini-live-exact/route.ts
+++ b/app/api/interview/test-gemini-live-exact/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server"
+import { GeminiStreamService } from "@/lib/gemini-stream-service"
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { voice = "Kore" } = body
+
+    const apiKey = process.env.GOOGLE_AI_API_KEY
+    if (!apiKey) {
+      return NextResponse.json({ success: false, error: "API key not configured" }, { status: 500 })
+    }
+
+    const audioChunks: string[] = []
+    const service = new GeminiStreamService(
+      apiKey,
+      {
+        job: { title: "Test", company: "Test" },
+        questions: { technical: [], behavioral: [] },
+        voice,
+      },
+      { onAudio: (d) => audioChunks.push(d) },
+    )
+
+    await service.startSession()
+    service.sendText("Exact format check")
+    await new Promise((r) => setTimeout(r, 1500))
+    service.close()
+
+    return NextResponse.json({
+      success: true,
+      message: "Exact format data retrieved",
+      audioSize: audioChunks.reduce((a, c) => a + c.length, 0),
+    })
+  } catch (error: any) {
+    console.error("test-gemini-live-exact error:", error)
+    return NextResponse.json({ success: false, error: error.message || "Unknown error" }, { status: 500 })
+  }
+}

--- a/app/api/interview/test-gemini-live/route.ts
+++ b/app/api/interview/test-gemini-live/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+import { GeminiStreamService } from "@/lib/gemini-stream-service"
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { testType = "basic", voice = "Kore" } = body
+
+    const apiKey = process.env.GOOGLE_AI_API_KEY
+    if (!apiKey) {
+      return NextResponse.json({ success: false, error: "API key not configured" }, { status: 500 })
+    }
+
+    const service = new GeminiStreamService(
+      apiKey,
+      {
+        job: { title: "Test", company: "Test" },
+        questions: { technical: [], behavioral: [] },
+        voice,
+      },
+    )
+
+    await service.startSession()
+    service.sendText(`This is a ${testType} test of the Gemini Live API.`)
+    await new Promise((r) => setTimeout(r, 1000))
+    service.close()
+
+    return NextResponse.json({ success: true, message: "Gemini Live API test completed" })
+  } catch (error: any) {
+    console.error("test-gemini-live error:", error)
+    return NextResponse.json({ success: false, error: error.message || "Unknown error" }, { status: 500 })
+  }
+}

--- a/components/interview-prep/live-interview.tsx
+++ b/components/interview-prep/live-interview.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Phone, PhoneCall, Mic, Volume2, Clock, Zap, AlertCircle, CheckCircle, Loader2, PhoneOff } from "lucide-react"
 import { LiveInterviewClient, type LiveInterviewConfig } from "@/lib/live-interview-client"
+import { SimpleMockInterview } from "@/components/interview-prep/simple-mock-interview"
 
 interface LiveInterviewProps {
   job: any
@@ -36,9 +37,14 @@ export function LiveInterview({ job, resume, questions }: LiveInterviewProps) {
   const [remainingTime, setRemainingTime] = useState(15 * 60 * 1000) // 15 minutes
   const [isAudioActive, setIsAudioActive] = useState(false)
   const [selectedVoice, setSelectedVoice] = useState<LiveInterviewConfig["voice"]>("Kore")
+  const [useFallback, setUseFallback] = useState(false)
 
   const clientRef = useRef<LiveInterviewClient | null>(null)
   const durationTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  if (useFallback) {
+    return <SimpleMockInterview job={job} resume={resume} questions={questions} />
+  }
 
   // Check if we have enough questions and required data
   const hasEnoughQuestions = questions.technical.length > 0 || questions.behavioral.length > 0
@@ -82,6 +88,7 @@ export function LiveInterview({ job, resume, questions }: LiveInterviewProps) {
             console.error("❌ Live interview error:", error)
             setError(error)
             setInterviewState("error")
+            setUseFallback(true)
           },
           onTimeWarning: (remainingMinutes) => {
             console.log(`⏰ Time warning: ${remainingMinutes} minutes remaining`)
@@ -124,6 +131,7 @@ export function LiveInterview({ job, resume, questions }: LiveInterviewProps) {
       console.error("❌ Failed to start live interview:", error)
       setError(`Failed to start interview: ${error.message}`)
       setInterviewState("error")
+      setUseFallback(true)
     }
   }
 

--- a/lib/gemini-stream-service.ts
+++ b/lib/gemini-stream-service.ts
@@ -1,0 +1,115 @@
+import { GoogleGenAI, Modality } from "@google/genai"
+
+export interface StreamCallbacks {
+  onOpen?: () => void
+  onMessage?: (message: any) => void
+  onError?: (error: any) => void
+  onClose?: () => void
+  onAudio?: (audioData: string) => void
+}
+
+export interface StreamInit {
+  job: { title: string; company: string; description?: string }
+  resume?: { content?: string }
+  questions: { technical: string[]; behavioral: string[] }
+  voice?: string
+}
+
+export class GeminiStreamService {
+  private ai: GoogleGenAI
+  private session: any | null = null
+  private voice: string
+  private callbacks: StreamCallbacks
+  private init: StreamInit
+
+  constructor(apiKey: string, init: StreamInit, callbacks: StreamCallbacks = {}) {
+    this.ai = new GoogleGenAI({ apiKey })
+    this.init = init
+    this.voice = init.voice || this.randomVoice()
+    this.callbacks = callbacks
+  }
+
+  private randomVoice(): string {
+    const voices = [
+      "Puck",
+      "Charon",
+      "Kore",
+      "Fenrir",
+      "Aoede",
+      "Leda",
+      "Orus",
+      "Zephyr",
+    ]
+    return voices[Math.floor(Math.random() * voices.length)]
+  }
+
+  private buildPrompt(): string {
+    const { job, resume, questions } = this.init
+    let prompt = `You are conducting a mock interview for the ${job.title} position at ${job.company}.`
+    if (job.description) {
+      prompt += `\nJOB DESCRIPTION:\n${job.description}`
+    }
+    if (resume?.content) {
+      prompt += `\nRESUME:\n${resume.content}`
+    }
+    prompt += "\nQUESTIONS TO COVER:";
+    questions.technical.forEach((q, i) => {
+      prompt += `\n${i + 1}. [TECHNICAL] ${q}`
+    })
+    questions.behavioral.forEach((q, i) => {
+      prompt += `\n${i + 1 + questions.technical.length}. [BEHAVIORAL] ${q}`
+    })
+    prompt += "\nConduct the interview in a natural manner.";
+    return prompt
+  }
+
+  async startSession(): Promise<void> {
+    const config = {
+      model: "gemini-2.0-flash-live-001",
+      callbacks: {
+        onopen: () => this.callbacks.onOpen?.(),
+        onmessage: (msg: any) => {
+          this.callbacks.onMessage?.(msg)
+          const parts =
+            msg.candidates?.[0]?.content?.parts || msg.serverContent?.modelTurn?.parts
+          if (parts) {
+            for (const part of parts) {
+              if (part.inlineData?.data) {
+                this.callbacks.onAudio?.(part.inlineData.data)
+              }
+            }
+          }
+        },
+        onerror: (e: any) => this.callbacks.onError?.(e),
+        onclose: () => this.callbacks.onClose?.(),
+      },
+      config: {
+        responseModalities: [Modality.AUDIO],
+        systemInstruction: { parts: [{ text: this.buildPrompt() }] },
+        speechConfig: { voiceName: this.voice },
+      },
+    }
+
+    this.session = await this.ai.live.connect(config as any)
+  }
+
+  sendAudio(audioData: ArrayBuffer) {
+    if (!this.session) return
+    const base64 = Buffer.from(audioData).toString("base64")
+    this.session.sendRealtimeInput({
+      audio: { data: base64, mimeType: "audio/pcm;rate=16000" },
+    })
+  }
+
+  sendText(text: string) {
+    if (!this.session) return
+    this.session.sendClientContent({ turns: text })
+  }
+
+  close() {
+    if (this.session) {
+      this.session.close()
+      this.session = null
+    }
+  }
+}

--- a/lib/live-interview-client.ts
+++ b/lib/live-interview-client.ts
@@ -1,0 +1,93 @@
+import { GeminiStreamService } from "@/lib/gemini-stream-service"
+
+export interface LiveInterviewConfig {
+  voice: "Puck" | "Charon" | "Kore" | "Fenrir" | "Aoede" | "Leda" | "Orus" | "Zephyr"
+  maxDuration: number
+  timeWarningAt: number
+}
+
+export interface LiveInterviewCallbacks {
+  onConnected?: () => void
+  onDisconnected?: () => void
+  onError?: (error: string) => void
+  onTimeWarning?: (minutesLeft: number) => void
+  onTimeUp?: () => void
+  onInterviewComplete?: () => void
+  onAudioReceived?: (data: ArrayBuffer) => void
+}
+
+export class LiveInterviewClient {
+  private service: GeminiStreamService
+  private config: LiveInterviewConfig
+  private callbacks: LiveInterviewCallbacks
+  private start = 0
+  private active = false
+  private timer: NodeJS.Timeout | null = null
+
+  private constructor(service: GeminiStreamService, config: LiveInterviewConfig, callbacks: LiveInterviewCallbacks) {
+    this.service = service
+    this.config = config
+    this.callbacks = callbacks
+  }
+
+  static async create(
+    job: any,
+    resume: any | undefined,
+    questions: { technical: string[]; behavioral: string[] },
+    config: LiveInterviewConfig,
+    callbacks: LiveInterviewCallbacks,
+  ): Promise<LiveInterviewClient> {
+    const apiKey = process.env.GOOGLE_AI_API_KEY || ""
+    const service = new GeminiStreamService(
+      apiKey,
+      { job, resume, questions, voice: config.voice },
+      {
+        onOpen: callbacks.onConnected,
+        onClose: callbacks.onDisconnected,
+        onError: (e) => callbacks.onError?.(e?.message || String(e)),
+        onAudio: (d) => callbacks.onAudioReceived?.(Buffer.from(d, "base64").buffer),
+      },
+    )
+
+    return new LiveInterviewClient(service, config, callbacks)
+  }
+
+  async startInterview() {
+    await this.service.startSession()
+    this.active = true
+    this.start = Date.now()
+    this.timer = setInterval(() => {
+      const elapsed = Date.now() - this.start
+      if (elapsed >= this.config.maxDuration) {
+        this.callbacks.onTimeUp?.()
+        this.endInterview()
+      } else if (elapsed >= this.config.timeWarningAt) {
+        const remaining = Math.round((this.config.maxDuration - elapsed) / 60000)
+        this.callbacks.onTimeWarning?.(remaining)
+      }
+    }, 1000)
+  }
+
+  sendAudio(data: ArrayBuffer) {
+    this.service.sendAudio(data)
+  }
+
+  isActive() {
+    return this.active
+  }
+
+  getInterviewDuration() {
+    return this.active ? Date.now() - this.start : 0
+  }
+
+  getRemainingTime() {
+    return this.config.maxDuration - (Date.now() - this.start)
+  }
+
+  endInterview() {
+    this.service.close()
+    this.active = false
+    if (this.timer) clearInterval(this.timer)
+    this.callbacks.onInterviewComplete?.()
+  }
+}


### PR DESCRIPTION
## Summary
- add Gemini streaming service and client
- expose API routes for testing Live API connectivity
- fallback to simple phone interview if live streaming fails

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68557ec0affc8326a085b7ab287374f8